### PR TITLE
Add resource cleanup hook

### DIFF
--- a/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
@@ -544,6 +544,7 @@ class EventStream(
                     is Either.Right -> emit(it.value)
                 }
             }
+            .cancellable()
             .retryWhen { cause: Throwable, attempt: Long ->
                 log.warn("streamBlocks::error; recovering Flow (attempt ${attempt + 1})")
                 when (cause) {


### PR DESCRIPTION
When the JVM is killed, sometimes the port-forwarded RPC stream that the `aggregate-service` listens to will hang or timeout, making testing more difficult across runs of the service. This hook explicitly cancels both the live and historic block streams, allowing the connection to the RPC to be closed normally.