### PR TITLE
Add more granular retry handling for Dynamo transactions

### DIFF
--- a/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
@@ -44,7 +44,7 @@ class EventStream(
 ) {
 
     companion object {
-        const val DEFAULT_BATCH_SIZE = 4
+        const val DEFAULT_BATCH_SIZE = 8
         const val TENDERMINT_MAX_QUERY_RANGE = 20
         const val DYNAMODB_BATCH_GET_ITEM_MAX_ITEMS = 100
     }


### PR DESCRIPTION
This PR fixes/improves the last attempt to correct the issue of concurrent writes to Dynamo, which was causing a `TransactionCancelledException` being raised. The previous implementation resulted in a mistaken attempt to re-insert all blocks from the previous failed attempt, when only the failed batch of blocks should have been re-inserted. I believe this is most likely the culprit behind the exception being raised. For example, if 100 blocks needed to be added to Dynamo for tracking, they needed to be split into groups of 25, since that's the maximum number of write requests that can occur in a transaction. If any one of the `transactWriteItems` calls failed, all blocks would be re-inserted (overwriting the existing records. From a data correctness standpoint, this was not an issue). However, the correct thing to do would only attempt to re-insert the failed group. Each block group is now wrapped in a block which will attempt to re-insert blocks in that group up to 5 times, with a backoff strategy adding a wait time + jitter.