### PR TITLE
Support transfer event for coin transfer between accounts

### DIFF
--- a/src/main/kotlin/io/provenance/aggregate/service/Main.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/Main.kt
@@ -234,6 +234,7 @@ fun main(args: Array<String>) {
 
         val options = EventStream.Options
             .builder()
+            .batchSize(config.eventStream.batch.size)
             .fromHeight(fromHeightGetter)
             .toHeight(toHeight?.toLong())
             .skipIfEmpty(skipIfEmpty)

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
@@ -217,9 +217,8 @@ class EventStreamUploader(
                 // Mark the blocks as having been processed:
                 val s3Keys = uploaded.map { it.s3Key }
                 val blockBatch: BlockBatch = BlockBatch(batch.id, aws.s3Config.bucket, s3Keys)
-
                 val writeResult: WriteResult = dynamo.trackBlocks(blockBatch, streamBlocks)
-                log.info("dynamo write result: $writeResult")
+                log.info("track block batch result: $writeResult")
 
                 //  At this point, signal success by emitting results:
                 emitAll(uploaded.asFlow())

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/CSVFileExtractor.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/CSVFileExtractor.kt
@@ -54,7 +54,7 @@ abstract class CSVFileExtractor(
      *
      * If `includeHash` is true, the computed hash value will be the first entry of the written record.
      */
-    fun syncWriteRecord(vararg values: Any?, includeHash: Boolean = true) {
+    fun syncWriteRecord(vararg values: Any?, includeHash: Boolean) {
         synchronized(this) {
             flagWriteOutput = true
             if (includeHash) {

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxCoinTransfer.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxCoinTransfer.kt
@@ -1,0 +1,67 @@
+package io.provenance.aggregate.service.stream.extractors.csv.impl
+
+import io.provenance.aggregate.service.extensions.toISOString
+import io.provenance.aggregate.service.stream.extractors.csv.CSVFileExtractor
+import io.provenance.aggregate.service.stream.models.StreamBlock
+import io.provenance.aggregate.service.stream.models.provenance.cosmos.Tx as CosmosTx
+
+/**
+ * Extract data related to the movement of coins between accounts
+ */
+class TxCoinTransfer : CSVFileExtractor(
+    name = "tx_coin_transfer",
+    headers = listOf(
+        "hash",
+        "event_type",
+        "block_height",
+        "block_timestamp",
+        "recipient",
+        "sender",
+        "amount",
+        "denom",
+    )
+) {
+    /**
+     * Given a string like `12275197065nhash`, where the amount and denomination are concatenated, split the string
+     * into separate amount and denomination strings.
+     *
+     * To determine amount, consume as many numeric values from the string until a non-numeric value is encountered.
+     */
+    private fun splitAmountAndDenom(str: String): Pair<String, String> {
+        val amount = StringBuilder(str)
+        val denom = StringBuilder()
+        for (i in str.length - 1 downTo 0) {
+            val ch = str[i]
+            if (!ch.isDigit()) {
+                amount.deleteCharAt(i)
+                denom.insert(0, ch)
+            } else {
+                break
+            }
+        }
+        return Pair(amount.toString(), denom.toString())
+    }
+
+    override suspend fun extract(block: StreamBlock) {
+        for (event in block.txEvents) {
+            CosmosTx.mapper.fromEvent(event)
+                ?.let { record: CosmosTx ->
+                    when (record) {
+                        is CosmosTx.Transfer -> {
+                            val (amount, denom) = splitAmountAndDenom(record.amountAndDenom)
+                            syncWriteRecord(
+                                event.eventType,
+                                event.blockHeight,
+                                event.blockDateTime?.toISOString(),
+                                record.recipient,
+                                record.sender,
+                                amount,
+                                denom,
+                                includeHash = true
+                            )
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxEventAttributes.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxEventAttributes.kt
@@ -38,7 +38,8 @@ class TxEventAttributes : CSVFileExtractor(
                         record.updatedValue ?: record.value,
                         record.updatedType ?: record.type,
                         record.account,
-                        record.owner
+                        record.owner,
+                        includeHash = true
                     )
                 }
         }

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxMarkerSupply.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxMarkerSupply.kt
@@ -52,6 +52,7 @@ class TxMarkerSupply : CSVFileExtractor(
                             record.metadataDenomUnits,
                             record.metadataName,
                             record.metadataSymbol,
+                            includeHash = true
                         )
                     }
                 }

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxMarkerTransfer.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/extractors/csv/impl/TxMarkerTransfer.kt
@@ -36,7 +36,8 @@ class TxMarkerTransfer : CSVFileExtractor(
                                 record.denom,
                                 record.administrator,
                                 record.toAddress,
-                                record.fromAddress
+                                record.fromAddress,
+                                includeHash = true
                             )
                         else -> {
                             // noop

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/models/provenance/attribute/EventAttribute.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/models/provenance/attribute/EventAttribute.kt
@@ -29,6 +29,8 @@ sealed class EventAttribute() : FromAttributeMap {
 
     /**
      * Convert an attribute instance to a consolidated attribute event.
+     *
+     * @return A consolidated event.
      */
     abstract fun toEventRecord(): ConsolidatedEvent
 

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/models/provenance/cosmos/Tx.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/models/provenance/cosmos/Tx.kt
@@ -1,0 +1,31 @@
+package io.provenance.aggregate.service.stream.models.provenance.cosmos
+
+import io.provenance.aggregate.service.extensions.transform
+import io.provenance.aggregate.service.stream.models.provenance.EventMapper
+import io.provenance.aggregate.service.stream.models.provenance.FromAttributeMap
+import io.provenance.aggregate.service.stream.models.provenance.MappedProvenanceEvent
+import io.provenance.aggregate.service.stream.models.provenance.debase64
+
+/**
+ * A sealed classes enumeration which models the Provenance event attributes:
+ *
+ * - `transfer`
+ */
+sealed class Tx() : FromAttributeMap {
+
+    companion object {
+        val mapper = EventMapper(Tx::class)
+    }
+
+    /**
+     * Represents the transfer of coin from one account to another.
+     *
+     * @see https://docs.cosmos.network/master/core/proto-docs.html#cosmos.bank.v1beta1.MsgSend
+     */
+    @MappedProvenanceEvent("transfer")
+    class Transfer(override val attributes: Map<String, String?>) : Tx() {
+        val recipient: String by attributes.transform(::debase64)
+        val sender: String by attributes.transform(::debase64)
+        val amountAndDenom: String by attributes.transform("amount", ::debase64)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ event-stream:
     uri: ${EVENT_STREAM_RPC_URI}
   batch:
     # Controls the maximum number of blocks that will be bundled into a batch for processing.
-    size: 16
+    size: 64
     # Controls the timeout for a batch. If a batch is incomplete and a new block has not been received within
     # `timeout` milliseconds, the batch will be emitted, despite the fact it has less the `size` blocks.
     # timeout-ms: 10000
@@ -43,6 +43,8 @@ event-stream:
       - provenance.marker.v1.EventMarkerSetDenomMetadata
       - provenance.marker.v1.EventMarkerTransfer
       - provenance.marker.v1.EventMarkerWithdraw
+      - transfer
+
     # A listing of block events to filter by. If no events are provided, filtering by blocks will be
     # disabled.
     # block-events:
@@ -57,3 +59,4 @@ upload:
     - io.provenance.aggregate.service.stream.extractors.csv.impl.TxEventAttributes
     - io.provenance.aggregate.service.stream.extractors.csv.impl.TxMarkerTransfer
     - io.provenance.aggregate.service.stream.extractors.csv.impl.TxMarkerSupply
+    - io.provenance.aggregate.service.stream.extractors.csv.impl.TxCoinTransfer

--- a/src/test/kotlin/io/provenance/aggregate/service/extractors/EventMetdataSessionCreated.kt
+++ b/src/test/kotlin/io/provenance/aggregate/service/extractors/EventMetdataSessionCreated.kt
@@ -20,7 +20,8 @@ class EventMetdataSessionCreated() : CSVFileExtractor(
                     event.blockHeight,
                     event.blockDateTime?.toISOString(),
                     eventMap["session_addr"],
-                    eventMap["scope_addr"]
+                    eventMap["scope_addr"],
+                    includeHash = true
                 )
             }
         }


### PR DESCRIPTION
- FEATURE: The Cosmos tx event MsgSend results in a txResponse "transfer"
  event documenting the transfer of coin between two accounts, which we now
  listen for.

- FIX: Despite batch size being a configuration param, it was not being
  passed to the event stream upon creation

- More documentation was added around mapping classes to event type
  strings.