### PR TITLE
Update max block height based on last successful upload to S3

### DIFF
--- a/common/src/main/kotlin/io/provenance/aggregate/common/models/UploadResult.kt
+++ b/common/src/main/kotlin/io/provenance/aggregate/common/models/UploadResult.kt
@@ -16,5 +16,5 @@ data class UploadResult(
     val batchSize: Int,
     val eTag: String,
     val s3Key: S3Key,
-    val blockHeightRange: String
+    val blockHeightRange: Pair<Long, Long>
 )

--- a/common/src/main/kotlin/io/provenance/aggregate/common/models/UploadResult.kt
+++ b/common/src/main/kotlin/io/provenance/aggregate/common/models/UploadResult.kt
@@ -15,5 +15,6 @@ data class UploadResult(
     val batchId: BatchId,
     val batchSize: Int,
     val eTag: String,
-    val s3Key: S3Key
+    val s3Key: S3Key,
+    val blockHeightRange: String
 )

--- a/src/main/kotlin/io/provenance/aggregate/service/Main.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/Main.kt
@@ -320,7 +320,8 @@ fun main(args: Array<String>) {
                 .upload()
                 .cancelOnSignal(shutDownSignal)
                 .collect { result: UploadResult ->
-                    log.info("uploaded #${result.batchId} => S3 ETag: ${result.eTag} => S3Key: ${result.s3Key} Block Height Range: ${result.blockHeightRange}")
+                    log.info("uploaded #${result.batchId} => S3 ETag: ${result.eTag} => S3Key: " +
+                            "${result.s3Key} Block Height Range: ${result.blockHeightRange.first} - ${result.blockHeightRange.second}")
                 }
         }
     }

--- a/src/main/kotlin/io/provenance/aggregate/service/Main.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/Main.kt
@@ -221,13 +221,16 @@ fun main(args: Array<String>) {
         // will be chosen as the starting height
 
         val fromHeightGetter: suspend () -> Long? = {
-            val maxHistoricalHeight: Long? = dynamo.getMaxHistoricalBlockHeight()
+            var maxHistoricalHeight: Long? = dynamo.getMaxHistoricalBlockHeight()
             log.info("Start :: historical max block height = $maxHistoricalHeight")
             if (restart) {
                 if (maxHistoricalHeight == null) {
                     log.warn("No historical max block height found; defaulting to 0")
                 } else {
-                    log.info("Restarting from historical max block height: $maxHistoricalHeight")
+                    log.info("Restarting from historical max block height: ${maxHistoricalHeight + 1}")
+                    // maxHistoricalHeight is last successful processed, to prevent processing this block height again
+                    // we need to increment.
+                    maxHistoricalHeight += 1
                 }
                 maxOf(maxHistoricalHeight ?: 0, fromHeight?.toLong() ?: 0)
             } else {
@@ -317,7 +320,7 @@ fun main(args: Array<String>) {
                 .upload()
                 .cancelOnSignal(shutDownSignal)
                 .collect { result: UploadResult ->
-                    println("uploaded #${result.batchId} => S3 ETag: ${result.eTag}")
+                    log.info("uploaded #${result.batchId} => S3 ETag: ${result.eTag} => S3Key: ${result.s3Key} Block Height Range: ${result.blockHeightRange}")
                 }
         }
     }

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/EventStream.kt
@@ -537,23 +537,12 @@ class EventStream(
         }
             .withIndex()
             .map { indexed ->
-                val index: Int = indexed.index
                 val heightPairChunk: List<Pair<Long, Long>> =
                     indexed.value // each pair will be `TENDERMINT_MAX_QUERY_RANGE` units apart
 
                 val lowest = heightPairChunk.minOf { it.first }
                 val highest = heightPairChunk.maxOf { it.second }
                 val fullBlockHeights: Set<Long> = (lowest..highest).toSet()
-
-                // Update every 2000 blocks:
-                if ((index % 20) == 0) {
-                    dynamo.writeMaxHistoricalBlockHeight(highest)
-                        .also {
-                            if (it.processed > 0) {
-                                log.info("historical::updating max historical block height to $highest")
-                            }
-                        }
-                }
 
                 // invariant:
                 assert(fullBlockHeights.size <= DYNAMODB_BATCH_GET_ITEM_MAX_ITEMS)
@@ -803,4 +792,3 @@ class EventStream(
             }
         }
 }
-

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/batch/Batch.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/batch/Batch.kt
@@ -62,7 +62,7 @@ data class Batch internal constructor(
                         .onFailure { e ->
                             log.error("processing error: ${e.message} ::")
                             for (frame in e.stackTrace) {
-                                log.error("  ${frame.toString()}")
+                                log.error("  ${frame}")
                             }
                         }
                 }

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
@@ -219,7 +219,7 @@ class EventStreamUploader(
                                             batchSize = streamBlocks.size,
                                             eTag = putResponse.eTag(),
                                             s3Key = key,
-                                            blockHeightRange = "${streamBlocks.first().height} ... ${streamBlocks.last().height}"
+                                            blockHeightRange = Pair(streamBlocks.first().height!!, streamBlocks.last().height!!)
                                         )
                                     } else {
                                         null

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
@@ -210,9 +210,9 @@ class EventStreamUploader(
                                                         log.info("historical::updating max historical block height to $blockHeight")
                                                     }
                                                 }
-                                        }
 
-                                        log.info("dest = ${aws.s3Config.bucket}/$key; eTag = ${putResponse.eTag()}")
+                                             log.info("dest = ${aws.s3Config.bucket}/$key; eTag = ${putResponse.eTag()}")
+                                        }
 
                                         UploadResult(
                                             batchId = batch.id,

--- a/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
+++ b/src/main/kotlin/io/provenance/aggregate/service/stream/consumers/EventStreamUploader.kt
@@ -184,7 +184,6 @@ class EventStreamUploader(
                             async { batch.processBlock(block) }
                         }
                             .awaitAll()
-
                         // Upload the results to S3:
                         batch.complete { batchId: BatchId, extractor: Extractor ->
                             val key: S3Key = csvS3Key(batchId, earliestDate, extractor.name)
@@ -196,12 +195,31 @@ class EventStreamUploader(
                                             override val body: AsyncRequestBody get() = AsyncRequestBody.fromFile(out.path)
                                             override val metadata: Map<String, String>? get() = out.metadata
                                         })
+
+                                        /**
+                                         * We want to track the last successful block height that was processed to S3, so
+                                         * in the event of an exception to the service, the service can restart
+                                         * at the last successful processed block height, so we don't lose any data that
+                                         * was in the middle of processing.
+                                         */
+                                         if(putResponse.sdkHttpResponse().isSuccessful) {
+                                            val blockHeight = streamBlocks.last().height  // this is the height we want to upload (last in the batch)
+                                            dynamo.writeMaxHistoricalBlockHeight(blockHeight!!)
+                                                .also {
+                                                    if(it.processed > 0) {
+                                                        log.info("historical::updating max historical block height to $blockHeight")
+                                                    }
+                                                }
+                                        }
+
                                         log.info("dest = ${aws.s3Config.bucket}/$key; eTag = ${putResponse.eTag()}")
+
                                         UploadResult(
                                             batchId = batch.id,
                                             batchSize = streamBlocks.size,
                                             eTag = putResponse.eTag(),
-                                            s3Key = key
+                                            s3Key = key,
+                                            blockHeightRange = "${streamBlocks.first().height} ... ${streamBlocks.last().height}"
                                         )
                                     } else {
                                         null

--- a/src/test/kotlin/io/provenance/aggregate/service/AWSTests.kt
+++ b/src/test/kotlin/io/provenance/aggregate/service/AWSTests.kt
@@ -159,6 +159,8 @@ class AWSTests : TestBase() {
         // This is due to the use of [delay] in the chunk() flow operator used by `EventStreamUploader`.
         val eventStreamOptions = EventStream.Options.DEFAULT.withBatchTimeout(null)
 
+        val lastBlockHeightFromStream = "2270469"
+
         runBlocking(dispatcherProvider.io()) {
 
             // There should be no results if no extractors run to actually extract data to upload:
@@ -212,7 +214,7 @@ class AWSTests : TestBase() {
             // The max height should have been set to that of the last live block received:
 
             val maxHeight = dynamo.getMaxHistoricalBlockHeight()
-            assert(maxHeight!= null  && maxHeight == "2270469".toLong())
+            assert(maxHeight!= null  && maxHeight == lastBlockHeightFromStream.toLong())
 
             // We should be able to check that maxHeight == MAX_LIVE_BLOCK_HEIGHT. However the order the live and
             // historical streams run in test is non-deterministic. If all of the live streams are received before

--- a/src/test/kotlin/io/provenance/aggregate/service/AWSTests.kt
+++ b/src/test/kotlin/io/provenance/aggregate/service/AWSTests.kt
@@ -212,7 +212,7 @@ class AWSTests : TestBase() {
             // The max height should have been set to that of the last live block received:
 
             val maxHeight = dynamo.getMaxHistoricalBlockHeight()
-            assert(dynamo.getMaxHistoricalBlockHeight() != null && maxHeight is Long)
+            assert(maxHeight!= null  && maxHeight == "2270469".toLong())
 
             // We should be able to check that maxHeight == MAX_LIVE_BLOCK_HEIGHT. However the order the live and
             // historical streams run in test is non-deterministic. If all of the live streams are received before
@@ -507,8 +507,8 @@ class AWSTests : TestBase() {
             }
 
             val record = s3.readContent(s3.listBucketObjectKeys()[0])
-            val amount1 = record[1].get(6).plus(record[1].get(7))
-            val amount2 = record[2].get(6).plus(record[2].get(7))
+            val amount1 = record[1].get(7).plus(record[1].get(8))
+            val amount2 = record[2].get(7).plus(record[2].get(8))
 
             assert(amount1 == "53126cfigurepayomni")
             assert(amount2 == "10000000000nhash")


### PR DESCRIPTION
When AWS or EventStream throws an exception, the aggregator will restart and if it was in the middle of uploading data to S3, those set of data would get lost.

To fix this, we will update the max block height after every successful batch push to S3.