### PR TITLE
Aggregator Api to request call for specific address's daily tx total.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ logback = "1.2.3"
 moshi = "1.13.0"
 hoplite = "2.1.3"
 json = "20210307"
+gson = "2.8.5"
 aws = "2.17.127"
 localstack = "0.2.14"
 grpc = "1.41.0"
@@ -27,6 +28,9 @@ dbUtils = "1.7"
 ravendb = "5.2.3"
 hdWallet = "0.1.15"
 jacksonModule = "2.11.0"
+ktor = "2.0.2"
+okhttp = "4.10.0"
+kodein = "7.10.0"
 
 pluginProtobuf = "0.18.7"
 pluginNexusPublishPlugin = "1.1.0"
@@ -50,6 +54,12 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinReflect" }
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization"}
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+
+ktor-core = { module = "io.ktor:ktor-server-core-jvm", version.ref="ktor" }
+ktor-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref="ktor" }
+ktor-status = { module = "io.ktor:ktor-server-status-pages-jvm", version.ref="ktor" }
+ktor-headers = { module = "io.ktor:ktor-server-default-headers-jvm", version.ref="ktor" }
+kodein = { module = "org.kodein.di:kodein-di-jvm", version.ref="kodein"}
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }
@@ -79,6 +89,7 @@ hoplite-core = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "ho
 hoplite-yaml = { module = "com.sksamuel.hoplite:hoplite-yaml", version.ref = "hoplite" }
 
 json = { module = "org.json:json", version.ref = "json" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 aws-bom = { module = "software.amazon.awssdk:bom", version.ref = "aws"}
 aws-netty = { module = "software.amazon.awssdk:netty-nio-client" }
@@ -98,6 +109,9 @@ commons-dbutils = { module = "commons-dbutils:commons-dbutils", version.ref = "d
 raven-db = { module = "net.ravendb:ravendb", version.ref = "ravendb" }
 hdwallet-bech32 = { module = "io.provenance.hdwallet:hdwallet-bech32", version.ref = "hdWallet"}
 hdwallet-common = { module = "io.provenance.hdwallet:hdwallet-common", version.ref = "hdWallet"}
+
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+
 
 [plugins]
 kapt = { id = "org.jetbrains.kotlin.kapt" }

--- a/repository/src/main/kotlin/io/provenance/aggregate/repository/database/ravendb/RavenDB.kt
+++ b/repository/src/main/kotlin/io/provenance/aggregate/repository/database/ravendb/RavenDB.kt
@@ -1,4 +1,4 @@
-package io.provenance.aggregate.repository.database
+package io.provenance.aggregate.repository.database.ravendb
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -18,7 +18,7 @@ import io.provenance.eventstream.stream.models.extensions.txHashes
 import net.ravendb.client.documents.DocumentStore
 import net.ravendb.client.documents.session.IDocumentSession
 
-class RavenDB(addr: String?, dbName: String?, maxConnections: Int): RepositoryBase {
+open class RavenDB(addr: String?, dbName: String?, maxConnections: Int): RepositoryBase {
 
     companion object {
         const val CHECKPOINT_ID = "BlockHeightCheckpoint"
@@ -59,7 +59,7 @@ class RavenDB(addr: String?, dbName: String?, maxConnections: Int): RepositoryBa
         saveChanges(session) // close session when done saving block data
     }
 
-    private fun openSession(): IDocumentSession {
+    protected fun openSession(): IDocumentSession {
         val mapper = jacksonObjectMapper().apply {
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
@@ -88,7 +88,7 @@ class RavenDB(addr: String?, dbName: String?, maxConnections: Int): RepositoryBa
             session.store(it)
         }
 
-    private fun saveChanges(session: IDocumentSession) {
+    protected fun saveChanges(session: IDocumentSession) {
         session.saveChanges()
         session.close()
     }

--- a/repository/src/main/kotlin/io/provenance/aggregate/repository/factory/RepositoryFactory.kt
+++ b/repository/src/main/kotlin/io/provenance/aggregate/repository/factory/RepositoryFactory.kt
@@ -4,7 +4,7 @@ import io.provenance.aggregate.common.DBConfig
 import io.provenance.aggregate.common.DbTypes.DYNAMODB
 import io.provenance.aggregate.common.DbTypes.RAVENDB
 import io.provenance.aggregate.repository.RepositoryBase
-import io.provenance.aggregate.repository.database.RavenDB
+import io.provenance.aggregate.repository.database.ravendb.RavenDB
 import io.provenance.aggregate.repository.database.dynamo.client.DynamoClient
 
 class RepositoryFactory(

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11
+
+ADD ./build/libs/*.jar /service/aggregator-address-loader-job.jar
+
+CMD ["java", "-jar", "/service/aggregator-address-loader-job.jar"]

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,0 +1,93 @@
+
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.serialization").version("1.6.21")
+    application
+    java
+    idea
+}
+
+group = "io.provenance.tech.aggregate"
+version = "0.0.1-SNAPSHOT"
+
+application {
+    mainClass.set("com.provenance.aggregator.api.ApplicationKt")
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.jetbrains.space/public/p/ktor/eap")
+    }
+}
+
+val javaTarget = JavaVersion.VERSION_11
+java.sourceCompatibility = javaTarget
+
+dependencies {
+    implementation(projects.common)
+    implementation(projects.repository)
+
+    implementation(libs.commons.dbutils)
+    implementation(libs.raven.db)
+    implementation(libs.okhttp)
+    implementation(libs.gson)
+
+    implementation(libs.ktor.core)
+    implementation(libs.ktor.netty)
+
+    implementation(libs.logback.classic)
+
+    implementation(libs.hoplite.core)
+    implementation(libs.hoplite.yaml)
+    implementation(libs.snowflake)
+
+    implementation(kotlin("stdlib"))
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+tasks.getByName<Test>("test") {
+    useJUnitPlatform()
+}
+
+tasks.compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += "-Xjsr305=strict"
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        jvmTarget = "11"
+    }
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs(
+                "$projectDir/src/main/kotlin",
+                "$buildDir/generated/src/main/kotlin"
+            )
+        }
+    }
+    test {
+        java {
+            srcDir("$projectDir/src/test/kotlin")
+        }
+    }
+}
+
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    manifest {
+        attributes["Main-Class"] = "com.provenance.aggregator.api.job.MainKt"
+    }
+    isZip64 = true
+    from(sourceSets.main.get().output)
+    dependsOn(configurations.runtimeClasspath)
+    from({
+        configurations.runtimeClasspath.get().map { if(it.isDirectory) it else zipTree(it)}
+    })
+
+
+    exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
+}

--- a/service/src/main/kotlin/Application.kt
+++ b/service/src/main/kotlin/Application.kt
@@ -1,6 +1,6 @@
 package com.provenance.aggregator.api
 
-import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.CacheConfig
 import com.provenance.aggregator.api.route.configureRouting
 import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.PropertySource
@@ -14,7 +14,7 @@ import java.util.Properties
 
 fun unwrapEnvOrError(variable: String): String = requireNotNull(System.getenv(variable)) { "Missing $variable" }
 
-fun loadConfig(): DbConfig {
+fun loadConfig(): CacheConfig {
     val environment: Environment =
         runCatching { Environment.valueOf(System.getenv("ENVIRONMENT")) }
             .getOrElse {

--- a/service/src/main/kotlin/Application.kt
+++ b/service/src/main/kotlin/Application.kt
@@ -1,0 +1,56 @@
+package com.provenance.aggregator.api
+
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.route.configureRouting
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.PropertySource
+import com.sksamuel.hoplite.addEnvironmentSource
+import com.sksamuel.hoplite.preprocessor.PropsPreprocessor
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.provenance.aggregate.common.Environment
+import java.util.Properties
+
+
+fun unwrapEnvOrError(variable: String): String = requireNotNull(System.getenv(variable)) { "Missing $variable" }
+
+fun loadConfig(): DbConfig {
+    val environment: Environment =
+        runCatching { Environment.valueOf(System.getenv("ENVIRONMENT")) }
+            .getOrElse {
+                error("Not a valid environment: ${System.getenv("ENVIRONMENT")}")
+            }
+
+    return ConfigLoader.builder()
+        .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
+        .apply {
+            if (environment.isLocal()) {
+                addPreprocessor(PropsPreprocessor("/local.env.properties"))
+            }
+        }
+        .addPropertySource(PropertySource.resource("/application.yaml"))
+        .build()
+        .loadConfigOrThrow()
+}
+
+fun main() {
+
+    val properties = Properties().apply {
+        put("user", unwrapEnvOrError("DB_USER"))
+        put("password", unwrapEnvOrError("DB_PASSWORD"))
+        put("warehouse", unwrapEnvOrError("DB_WAREHOUSE"))
+        put("db", unwrapEnvOrError("DB_DATABASE"))
+        put("schema", unwrapEnvOrError("DB_SCHEMA"))
+        put("networkTimeout", "30")
+        put("queryTimeout", "30")
+    }
+
+    val dbUri = "jdbc:snowflake://${unwrapEnvOrError("DB_HOST")}.snowflakecomputing.com"
+
+    embeddedServer(Netty, port=8081) {
+       configureRouting(properties, dbUri, loadConfig())
+    }.start(wait = true)
+}
+
+
+

--- a/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
@@ -1,0 +1,89 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.cache
+
+import com.google.gson.Gson
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.com.provenance.aggregator.api.model.Response
+import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxCoinTransferData
+import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxDailyTotal
+import com.provenance.aggregator.api.service.AccountService
+import com.provenance.aggregator.api.snowflake.SnowflakeJDBC
+import io.ktor.http.HttpStatusCode
+import io.provenance.aggregate.common.logger
+import io.provenance.aggregate.repository.database.ravendb.RavenDB
+import net.ravendb.client.Constants
+import net.ravendb.client.documents.session.IDocumentSession
+import net.snowflake.client.jdbc.internal.joda.time.DateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+class CacheService(
+    private val sf: SnowflakeJDBC,
+    private val config: DbConfig
+): RavenDB(
+    config.addr,
+    config.dbName,
+    config.dbMaxConnections
+) {
+
+    private val log = logger()
+    private val accountService = AccountService()
+
+    fun getTx(addr: String, date: OffsetDateTime): Response {
+        val session = openSession()
+        val record = session.query(TxCoinTransferData::class.java)
+            .whereEquals("sender", addr)
+            .whereBetween("blockTimestamp", date.format(DateTimeFormatter.ISO_LOCAL_DATE), date.plusDays(1).format(
+                DateTimeFormatter.ISO_LOCAL_DATE))
+            .toList()
+
+        if(record.isEmpty()) {
+            //No previous data found, retrieve then cache into raven.
+            log.debug("transaction data for address $addr is not available in cache")
+
+            val addrTxs: List<TxCoinTransferData> = loadFromDataWarehouse(addr, date)
+            if(addrTxs.isNotEmpty()) {
+                log.debug("snowflake results found: ${addrTxs.size}")
+
+                // cache the data retrieved
+                addrTxs.map { txCoinTransfer ->
+                    session.store(txCoinTransfer, txCoinTransfer.hash)
+                    //Set eviction after 7 days.
+                    configureEviction(txCoinTransfer, session)
+                }
+
+                saveChanges(session)
+
+                // calc the daily transaction in hash
+                val calcResults = accountService.calcDailyTransactionHash(addrTxs)
+                return Response(
+                    TxDailyTotal(addr, date.toString(), calcResults).json(),
+                    HttpStatusCode.OK
+                ).also { log.info(it.toString()) }
+            } else {
+                log.info("no transaction found from snowflake")
+                return Response(
+                    "$addr with date $date not found",
+                    HttpStatusCode.NotFound
+                ).also { log.info(it.toString()) }
+            }
+        }else {
+            log.info("Found data from ravendb: ${record.size}")
+            return Response(
+                TxDailyTotal(addr, date.toString(), accountService.calcDailyTransactionHash(record)).json(),
+                HttpStatusCode.OK
+            ).also {
+                log.info(it.toString())
+            }
+        }
+    }
+
+    private fun loadFromDataWarehouse(address: String, queryDate: OffsetDateTime) = sf.executeQuery(address, queryDate)
+
+    private fun configureEviction(txData: TxCoinTransferData, session: IDocumentSession) {
+        //Evict data after 7 days
+        val expiry = DateTime.now().plusDays(7)
+        session.advanced().getMetadataFor(txData)[Constants.Documents.Metadata.EXPIRES] = expiry
+    }
+}
+
+fun Any.json(): String = Gson().toJson(this)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
@@ -1,7 +1,7 @@
 package com.provenance.aggregator.api.com.provenance.aggregator.api.cache
 
 import com.google.gson.Gson
-import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.CacheConfig
 import com.provenance.aggregator.api.com.provenance.aggregator.api.model.Response
 import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxCoinTransferData
 import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxDailyTotal
@@ -18,11 +18,11 @@ import java.time.format.DateTimeFormatter
 
 class CacheService(
     private val sf: SnowflakeJDBC,
-    private val config: DbConfig
+    private val config: CacheConfig
 ): RavenDB(
-    config.addr,
-    config.dbName,
-    config.dbMaxConnections
+    config.cacheAddr,
+    config.cacheName,
+    config.cacheMaxConnections
 ) {
 
     private val log = logger()

--- a/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/cache/CacheService.kt
@@ -20,9 +20,9 @@ class CacheService(
     private val sf: SnowflakeJDBC,
     private val config: CacheConfig
 ): RavenDB(
-    config.cacheAddr,
+    config.addr,
     config.cacheName,
-    config.cacheMaxConnections
+    config.dbMaxConnections
 ) {
 
     private val log = logger()

--- a/service/src/main/kotlin/com/provenance/aggregator/api/config/CacheConfig.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/config/CacheConfig.kt
@@ -2,9 +2,9 @@ package com.provenance.aggregator.api.com.provenance.aggregator.api.config
 
 import io.provenance.aggregate.common.DbTypes
 
-data class DbConfig(
+data class CacheConfig(
     val addr: String,
-    val dbName: String,
+    val cacheName: String,
     val dbMaxConnections: Int,
     val dbType: DbTypes,
 )

--- a/service/src/main/kotlin/com/provenance/aggregator/api/config/DbConfig.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/config/DbConfig.kt
@@ -1,0 +1,10 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.config
+
+import io.provenance.aggregate.common.DbTypes
+
+data class DbConfig(
+    val addr: String,
+    val dbName: String,
+    val dbMaxConnections: Int,
+    val dbType: DbTypes,
+)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/job/JobConfig.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/job/JobConfig.kt
@@ -1,0 +1,5 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.job
+
+data class JobConfig(
+    val addrs: Map<String, String>
+)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/job/Main.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/job/Main.kt
@@ -1,0 +1,50 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.job
+
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.PropertySource
+import com.sksamuel.hoplite.addEnvironmentSource
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import org.slf4j.LoggerFactory
+
+fun loadJobConfig(): JobConfig {
+    return ConfigLoader.builder()
+        .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
+        .addPropertySource(PropertySource.resource("/address.yaml"))
+        .build()
+        .loadConfigOrThrow()
+}
+
+fun main() {
+    val log = LoggerFactory.getLogger("main")
+    val addresses = loadJobConfig()
+    val client = OkHttpClient()
+
+    addresses.addrs.map {
+        val url = "http://localhost:8081/address/${it.key}?date=${OffsetDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE)}"
+
+        val request = Request.Builder()
+            .url(url)
+            .build()
+
+        client.newCall(request).enqueue(object: Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    e.printStackTrace()
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    response.use{
+                        log.info(response.body?.string())
+                    }
+                }
+            }
+        )
+    }
+}
+

--- a/service/src/main/kotlin/com/provenance/aggregator/api/model/Response.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/model/Response.kt
@@ -1,0 +1,8 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.model
+
+import io.ktor.http.HttpStatusCode
+
+data class Response (
+    val message: String,
+    val statusCode: HttpStatusCode
+)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/model/TxCoinTransferData.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/model/TxCoinTransferData.kt
@@ -1,0 +1,13 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.model
+
+data class TxCoinTransferData(
+    val hash: String,
+    val eventType: String,
+    val blockHeight: Double,
+    val blockTimestamp: String,
+    val txHash: String,
+    val recipient: String,
+    val sender: String,
+    val amount: String,
+    val denom: String
+)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/model/TxDailyTotal.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/model/TxDailyTotal.kt
@@ -1,0 +1,10 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.model
+
+import java.time.OffsetDateTime
+
+data class TxDailyTotal(
+    val addr: String,
+    val date: String,
+    val total: Long,
+    val denom: String = "nhash"
+)

--- a/service/src/main/kotlin/com/provenance/aggregator/api/route/Routing.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/route/Routing.kt
@@ -2,7 +2,7 @@ package com.provenance.aggregator.api.route
 
 import com.provenance.aggregator.api.com.provenance.aggregator.api.cache.CacheService
 import com.provenance.aggregator.api.com.provenance.aggregator.api.cache.json
-import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.CacheConfig
 import com.provenance.aggregator.api.snowflake.SnowflakeJDBC
 import io.ktor.http.HttpStatusCode.Companion
 import io.ktor.server.application.Application
@@ -17,7 +17,7 @@ import java.time.format.DateTimeFormatter
 
 import java.util.Properties
 
-fun Application.configureRouting(properties: Properties, dbUri: String, dbConfig: DbConfig) {
+fun Application.configureRouting(properties: Properties, dbUri: String, dbConfig: CacheConfig) {
 
     val cacheService = CacheService(SnowflakeJDBC(properties, dbUri), dbConfig)
 

--- a/service/src/main/kotlin/com/provenance/aggregator/api/route/Routing.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/route/Routing.kt
@@ -1,0 +1,45 @@
+package com.provenance.aggregator.api.route
+
+import com.provenance.aggregator.api.com.provenance.aggregator.api.cache.CacheService
+import com.provenance.aggregator.api.com.provenance.aggregator.api.cache.json
+import com.provenance.aggregator.api.com.provenance.aggregator.api.config.DbConfig
+import com.provenance.aggregator.api.snowflake.SnowflakeJDBC
+import io.ktor.http.HttpStatusCode.Companion
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+import java.util.Properties
+
+fun Application.configureRouting(properties: Properties, dbUri: String, dbConfig: DbConfig) {
+
+    val cacheService = CacheService(SnowflakeJDBC(properties, dbUri), dbConfig)
+
+    routing {
+        get("/address/{addr?}") {
+            val address = call.parameters["addr"].toString()
+            val date = call.request.queryParameters["date"].toString()
+
+            try {
+                val queryDate = OffsetDateTime.of(
+                    LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay(),
+                    ZoneOffset.UTC
+                )
+
+                //check the cache table for the specific address requested
+                val response = cacheService.getTx(address, queryDate)
+                call.respond(response.statusCode, response.message)
+            } catch (e: Exception) {
+                call.respond(Companion.BadRequest, e.message!!.json())
+            }
+        }
+    }
+}
+
+

--- a/service/src/main/kotlin/com/provenance/aggregator/api/service/AccountService.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/service/AccountService.kt
@@ -1,0 +1,18 @@
+package com.provenance.aggregator.api.service
+
+import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxCoinTransferData
+
+class AccountService{
+
+    fun calcDailyTransactionHash(txList: List<TxCoinTransferData>): Long {
+        var totalHashAmt: Long = 0;
+        txList.map {
+            totalHashAmt = if(totalHashAmt.toInt() == 0) {
+                it.amount.toLong()
+            } else {
+                totalHashAmt + it.amount.toLong()
+            }
+        }
+        return totalHashAmt
+    }
+}

--- a/service/src/main/kotlin/com/provenance/aggregator/api/snowflake/QueryBuilder.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/snowflake/QueryBuilder.kt
@@ -1,0 +1,37 @@
+package com.provenance.aggregator.api.com.provenance.aggregator.api.snowflake
+
+class QueryBuilder(
+    val statement: String,
+    val columns: List<String>,
+    val table: String,
+    val criteria: String
+) {
+
+    companion object {
+        fun builder() = Builder()
+    }
+
+    class Builder {
+        private var statement: String = ""
+        private var columns: List<String> = mutableListOf()
+        private var table: String = ""
+        private var criteria: String = ""
+
+        fun statement(value: String) = apply { statement = value }
+
+        fun columns(value: List<String>) = apply { columns = value }
+
+        fun table(value: String) = apply { table = value }
+
+        fun criteria(value: String) = apply { criteria = value }
+
+        fun build(): QueryBuilder {
+            return QueryBuilder(
+                statement,
+                columns,
+                table,
+                criteria
+            )
+        }
+    }
+}

--- a/service/src/main/kotlin/com/provenance/aggregator/api/snowflake/SnowflakeJDBC.kt
+++ b/service/src/main/kotlin/com/provenance/aggregator/api/snowflake/SnowflakeJDBC.kt
@@ -1,0 +1,42 @@
+package com.provenance.aggregator.api.snowflake
+
+import com.provenance.aggregator.api.com.provenance.aggregator.api.model.TxCoinTransferData
+import org.apache.commons.dbutils.QueryRunner
+import org.apache.commons.dbutils.handlers.MapListHandler
+import java.sql.DriverManager
+import java.time.OffsetDateTime
+import java.util.Properties
+
+class SnowflakeJDBC(
+    properties: Properties,
+    dbUri: String
+) {
+
+    private val conn = DriverManager.getConnection(dbUri, properties)
+
+    fun executeQuery(addr: String, currOffSetDate: OffsetDateTime): List<TxCoinTransferData> {
+
+        val nextDate = currOffSetDate.plusDays(1)
+
+        val queryStmt = "SELECT * FROM COIN_TRANSFER " +
+                "WHERE BLOCK_TIMESTAMP BETWEEN '$currOffSetDate' and '$nextDate' " +
+                "AND SENDER='$addr';"
+
+        val resultData = QueryRunner().query(conn, queryStmt, MapListHandler()).toList()
+
+        return resultData.map { result ->
+            TxCoinTransferData(
+                result["HASH"].toString(),
+                result["EVENT_TYPE"].toString(),
+                result["BLOCK_HEIGHT"] as Double,
+                result["BLOCK_TIMESTAMP"].toString(),
+                result["TX_HASH"].toString(),
+                result["RECIPIENT"].toString(),
+                result["SENDER"].toString(),
+                result["AMOUNT"].toString(),
+                result["DENOM"].toString()
+            )
+        }
+    }
+
+}

--- a/service/src/main/resources/address.yaml
+++ b/service/src/main/resources/address.yaml
@@ -1,0 +1,51 @@
+addrs:
+  pb1kquvh9mqkzn6qkslcswm64aefcgn69w6rq8nf4: Accounting Wallet
+  pb1xvd4k9jg5h0d4dhzr4z0txtwe9p5zxf58xcmxd: Origination - Figure
+  pb1yvmg7c0hmhunrr6mrh5vz3mu4g2z06l5y842xz: Origination - Homebridge
+  pb174pdevzaulwrm68ly2d37jpe2d02glftdyvnr5: Origination - Homepoint
+  pb1g7n9qcd7zzpafv0zx8u6gdqvj34aalqapygrks: Origination - SynergyOne
+  pb1q4jdcwg350cqsdzn6jy8fxln9mx5rg7dm5mzs7: P8E Service Account
+  pb1x3v3kgvg4p5l007gjnmckgfmvw87tvd8z7clu4: Figure Validator 1 Operator Account
+  pb1d7yum2cxwkhmmuxa096prlv5gawjxw0ghau5h6: Figure Validator 2 Operator Account
+  pb157vsjx6f3pvd0gszvh6q6emc04trpznw0yt7um: Figure Validator 3 Operator Account
+  pb16xt2xdmunjmye2y2yjrxmc05s7r2yzhtt0ypnh: Figure Validator 4 Operator Account
+  pb1438hks7r47p22z2pqxv9eax369fq7vza20we85: Engineering Gas Pumper 1
+  pb1j542zhlsuwva0gyylu88qmhj5heg5a28arywhe: Engineering Gas Pumper 2
+  pb1szqxndh3nyxsukk90j8j0ev2dr8jhacd0894jn: Engineering Gas Pumper 3
+  pb1zsherr3eat6gvq9ptg3m0n3dj33xf2mwevk3ca: Portfolio Manager - Service Account
+  pb175gx39t90xyg88fx0jqwrfp5ppusaekrl0cggk: Figure Marketplace - Service Account
+  pb1evdjjcagllgyf23pzf7e2gkvfuakegsnv49yhj: Blank
+  pb1qhqw7ra3hq63uj2ca72afdlwhe6cynhep46new: Figure Secondary transaction account (grants)
+  pb1l00u2u8vzd6wvxxtsn0kel3gn870g39v4vx2fn: Figure Secondary holding account
+  pb1g2m2vp59amxd0hp5502e22hp0yprujd23z4qah: Omnibus Figure Pay
+  pb13p3fe2ydk7p6q9th5gl5ha4vmnz3ztpheqmkvz: Omnibus FTI Service Account
+  pb1949aeejayfs4srtl8sc672h2m03xarz46unz4q: Adnales service account (grants)
+  pb1v2km7r7fsuvsqk48fx743727p3d4tq6q80pdq7: Provenance Name Admin
+  pb1um2l2ldslc6r39kc5qzrddx6zydgpvny6aya7k: Passport - Service Account
+  pb1c4nq3c0qf0p4ufn64d4vnxvj3zx7ycsl88t9w6: Market Maker
+  pb1yqrsjmk7dwqjeru8t5y7xhlyqquxes25sm46z7: Provenance Foundation
+  pb18nzv4gyw6smf5uuealhkn0gl0c4n4e42xre2ym: Figure IBC Relay Service Account
+  pb1yxzcfkxkn7jymyzrdp9cc9eta3qelw8f4kcny9: Figure Tech US-East Validator
+  pb18jjl8wpgfre5han4akyxj4lhvy0v9t9xfq2w82: Figure Tech US-West Validator
+  pb1zza9vjvdpw2gwwml9wss3afsa600qw2vcathe8: Figure Governance wallet
+  pb1x45alqymesclp6yfzjsjsl5juzly8nfdtsunja: ATS Attribute Wallet
+  pb1mcyukv73v57jm2cq48p6y666kqjed8suyphshq: USDF.cc > NYCB.dcc > cash wallet
+  pb128fzvu8lgh92k7wywfnk5m4zx0feljh5czw9rq: Holder wallet (these transactions signed by mkvz)
+  pb1qhkfgluxwhalwps6y8fehxa7trqlhka2tjglk5: DCC Governance account / Contract Maintenance
+  pb1pr5ekk8nndfmla093q5yrrmzhgg2zcsj4kdqhe: Pay System Fee Payer Acct
+  pb1vm73d2qtvs86e2dguxt40tjzhv37r36h40wtqg: Omnibus Figure Lending
+  pb1u9t9ung76wzw88jhr0pa5szvl6ystdfe200hp3: Flomni Holder wallet (these transactions signed by 9jvt)
+  pb1gnrl9cx8f7yll5jgky6u5e5s99e294th8cqgpp: DCC Purchaser wallet
+  pb19yqkp7emc6e272uqy7dlcdty7ashuejyxtkyqp: USDF Marker Purchasing wallet
+  pb1gs9m84kyw7jd2ha0393v8dgu9pmkql95afvqe3: HomePoint Fee Payer Acct
+  pb1tq82hx5v7kekt7y58yu7t06yqwy28vejhm8e2s: HomePoint Purchasing Acct
+  pb1pg7gy8nnkuxdzz8dypt5vapkz92cl8lax7qjvg: Synergy Fee Payer Acct
+  pb12h0zwkjl04jdvzaxldxsm2nswztt6zw6h0v5vf: Synergy Purchasing Acct
+  pb1gqy3rsjha8kfazfsam4wd5tj342j8ad2kn5cq4: Figure Lending Purchasing Acct
+  pb13dfvqt7zyp69z3el72qsu6z3f0egh9xfng9jvt: Figure Lending Fee Payer Acct
+  pb193ndd83lql2aml4hq7kc9urm6sk74sgjwm6c8d: Loan Boarding Hash Purchas Acct
+  pb1jlkx797ys6h9dadtlehgapp5lpzne89c2rprs3: HomeBridge Fee Payer Acct
+  pb1dkaxcrcktjkf6gh0awqwm72v9cd240m03t02qs: HomeBridge Purchasing Acct
+  pb15mkw2s7pkkcdhueyv62ya3p8s3dpt83d0wufjs: Figure Pay Funding Account
+  pb1hf29xmfarhra7aj9ht40paaje4lkv4xu7y84rg: Figure Pay Incentive Funding Account
+  pb1jdhhd54zy6g3sg2agwuh503mdwm50e8es6d2l4: Main Hash Treasury Account

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -1,0 +1,4 @@
+addr: ${DB_URI}
+dbName: ${DB_TABLE}
+dbType: ${DB_TYPE}
+dbMaxConnections: ${DB_MAX_CONNECTIONS}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -1,4 +1,4 @@
 addr: ${DB_URI}
-dbName: ${DB_TABLE}
+cacheName: ${CACHE_TABLE}
 dbType: ${DB_TYPE}
 dbMaxConnections: ${DB_MAX_CONNECTIONS}

--- a/service/src/main/resources/local.env.properties
+++ b/service/src/main/resources/local.env.properties
@@ -1,0 +1,4 @@
+DB_URI=http://localhost:8080
+DB_TABLE=Aggregator-Cache
+DB_TYPE=RAVENDB
+DB_MAX_CONNECTIONS=100

--- a/service/src/main/resources/local.env.properties
+++ b/service/src/main/resources/local.env.properties
@@ -1,4 +1,4 @@
 DB_URI=http://localhost:8080
-DB_TABLE=Aggregator-Cache
+CACHE_TABLE=Aggregator-Cache
 DB_TYPE=RAVENDB
 DB_MAX_CONNECTIONS=100

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,4 +13,6 @@ pluginManagement {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-include("augment", "common", "repository")
+include("augment", "common", "repository", "service")
+include("job")
+include("job")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,4 @@ pluginManagement {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-include("augment", "common", "repository", "service")
-include("job")
-include("job")
+include("augment", "common", "repository", "service", "job")


### PR DESCRIPTION
- Initial implementation aggregator api to retrieve daily transaction total in nhash, the data is cached into RavenDB after being retrieved from Snowflake to limit the amount of query to Snowflake and to retrieve data much faster for repeated queries.

- PR also contains a job that runs right before midnight to grab the today's TX for 50 uniquely defined addresses and stores them into RavenDB (cache) so that they are readily available for querying the next day.

> I may need to test for edge cases to handle last minute Txs before the job execute.